### PR TITLE
Fix insecure token generation.

### DIFF
--- a/context.go
+++ b/context.go
@@ -150,7 +150,7 @@ func (ctx *Context) XSRFToken(specifiedExpiration ...int) string {
 		token, ok := ctx.SecureCookieParam(ctx.frame.config.XSRF.Key, "_xsrf")
 		if !ok {
 			ctx._xsrfTokenReset = true
-			token = string(utils.RandomBytes(32))
+			token = utils.RandomString(32)
 			if len(specifiedExpiration) > 0 && specifiedExpiration[0] > 0 {
 				ctx.xsrfExpire = specifiedExpiration[0]
 			} else if ctx.xsrfExpire == 0 {

--- a/helper.go
+++ b/helper.go
@@ -216,10 +216,6 @@ var ObjectName = utils.ObjectName
 //  func CleanPath(p string) string
 var CleanPath = utils.CleanPath
 
-// RandomBytes generate random []byte by specify chars.
-//  func RandomBytes(length int, alphabets ...byte) []byte
-var RandomBytes = utils.RandomBytes
-
 /**
  * define internal middlewares.
  */

--- a/session/sess_cookie.go
+++ b/session/sess_cookie.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+
+	"github.com/henrylee2cn/faygo/utils"
 )
 
 var cookiepder = &CookieProvider{}
@@ -122,10 +124,10 @@ func (pder *CookieProvider) SessionInit(maxlifetime int64, config string) error 
 		return err
 	}
 	if pder.config.BlockKey == "" {
-		pder.config.BlockKey = string(generateRandomKey(16))
+		pder.config.BlockKey = utils.RandomString(16)
 	}
 	if pder.config.SecurityName == "" {
-		pder.config.SecurityName = string(generateRandomKey(20))
+		pder.config.SecurityName = utils.RandomString(16)
 	}
 	pder.block, err = aes.NewCipher([]byte(pder.config.BlockKey))
 	if err != nil {

--- a/session/sess_utils.go
+++ b/session/sess_utils.go
@@ -18,14 +18,12 @@ import (
 	"bytes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha1"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -69,15 +67,6 @@ func DecodeGob(encoded []byte) (map[interface{}]interface{}, error) {
 	return out, nil
 }
 
-// generateRandomKey creates a random key with the given strength.
-func generateRandomKey(strength int) []byte {
-	k := make([]byte, strength)
-	if n, err := io.ReadFull(rand.Reader, k); n != strength || err != nil {
-		return utils.RandomBytes(strength)
-	}
-	return k
-}
-
 // Encryption -----------------------------------------------------------------
 
 // encrypt encrypts a value using the given block in counter mode.
@@ -85,7 +74,7 @@ func generateRandomKey(strength int) []byte {
 // A random initialization vector (http://goo.gl/zF67k) with the length of the
 // block size is prepended to the resulting ciphertext.
 func encrypt(block cipher.Block, value []byte) ([]byte, error) {
-	iv := generateRandomKey(block.BlockSize())
+	iv := utils.RandomBytes(block.BlockSize())
 	if iv == nil {
 		return nil, errors.New("encrypt: failed to generate random iv")
 	}

--- a/utils/rand.go
+++ b/utils/rand.go
@@ -2,29 +2,25 @@ package utils
 
 import (
 	"crypto/rand"
-	r "math/rand"
-	"time"
+	"encoding/base64"
 )
 
-var alphaNum = []byte(`0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz`)
+// RandomBytes returns securely generated random bytes. It will panic
+// if the system's secure random number generator fails to function correctly.
+func RandomBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		panic(err)
+	}
 
-// RandomBytes generate random []byte by specify chars.
-func RandomBytes(length int, alphabets ...byte) []byte {
-	if len(alphabets) == 0 {
-		alphabets = alphaNum
-	}
-	var bytes = make([]byte, length)
-	var randBy bool
-	if num, err := rand.Read(bytes); num != length || err != nil {
-		r.Seed(time.Now().UnixNano())
-		randBy = true
-	}
-	for i, b := range bytes {
-		if randBy {
-			bytes[i] = alphabets[r.Intn(len(alphabets))]
-		} else {
-			bytes[i] = alphabets[b%byte(len(alphabets))]
-		}
-	}
-	return bytes
+	return b
+}
+
+// RandomString returns a URL-safe, base64 encoded securely generated
+// random string. It will panic if the system's secure random number generator
+// fails to function correctly.
+func RandomString(n int) string {
+	return base64.URLEncoding.EncodeToString(RandomBytes(n))
 }

--- a/utils/rand_test.go
+++ b/utils/rand_test.go
@@ -1,35 +1,36 @@
 package utils
 
 import (
-	"sync"
+	"crypto/rand"
+	"io"
 	"testing"
 )
 
+const tokenLength = 32
+
+// shortReader provides a broken implementation of io.Reader for testing.
+type shortReader struct{}
+
+func (sr shortReader) Read(p []byte) (int, error) {
+	return len(p) % 2, io.ErrUnexpectedEOF
+}
+
+// TestRandomBytes tests the (extremely rare) case that crypto/rand does
+// not return the expected number of bytes.
 func TestRandomBytes(t *testing.T) {
-	m := map[string]bool{}
-	var lock sync.Mutex
-	var group sync.WaitGroup
-	count := 5000
-	group.Add(count)
-	for i := 0; i < count; i++ {
-		go func() {
-			id := string(RandomBytes(6))
-			lock.Lock()
-			m[id] = true
-			lock.Unlock()
-			group.Done()
-		}()
-	}
-	group.Wait()
-	if len(m) != count {
-		t.Fail()
-	}
-	var i int
-	for id := range m {
-		i++
-		if i > 10 {
-			break
+	// Pioneered by https://github.com/justinas/nosurf
+	original := rand.Reader
+	rand.Reader = shortReader{}
+	defer func() {
+		rand.Reader = original
+	}()
+
+	var b = make([]byte, tokenLength)
+	defer func() {
+		if err := recover(); err == nil {
+			t.Fatalf("RandomBytes did not report a short read: only read %d bytes", len(b))
 		}
-		t.Log(id)
-	}
+	}()
+
+	b = RandomBytes(tokenLength)
 }


### PR DESCRIPTION
- No longer fall back to math/rand
- base64 encode the output where a string is needed to remove the risk of biased output
- Update cases where these functions are used.
- Improve tests