### PR TITLE
与session中的enable_sid_in_urlquery有冲突

### DIFF
--- a/apiware/paramapi.go
+++ b/apiware/paramapi.go
@@ -456,7 +456,7 @@ func (paramsAPI *ParamsAPI) BindFields(
 	if pathParams == nil {
 		pathParams = Map(map[string]string{})
 	}
-	if req.Form == nil {
+	if req.MultipartForm == nil {
 		req.ParseMultipartForm(paramsAPI.maxMemory)
 	}
 	var queryValues url.Values


### PR DESCRIPTION
当session配置开启enable_sid_in_urlquery后，与faygo/session/session.go文件中168行 r.ParseForm() 执行后，有冲突 。