### PR TITLE
fix swagger example value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ samples/demo/demo
 
 ext/services
 .DS_Store
+.idea

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -302,7 +302,12 @@ func CreateProperties(obj interface{}) map[string]*Property {
 				fv = reflect.New(ft).Elem()
 			}
 			p.Default = fv.Interface()
-			ps[field.Name] = p
+			n := field.Tag.Get("json")
+			if n == "" {
+				ps[field.Name] = p
+			} else {
+				ps[n] = p
+			}
 		}
 		return ps
 


### PR DESCRIPTION
apidoc body的example value使用的是结构体的字段名，如UserName，但是实际开发过程中，会存在大家使用json注释的情况，即user_name，目前body里面的example value即使加了json注释也仍然是使用结构体的字段名，实际调试起来还要对example value进行修改，非常不方便，所以这里需要增加一个判断条件，如果存在json注释的话，property的key改为json的值