### PR TITLE
fix path params check

### DIFF
--- a/muxapi.go
+++ b/muxapi.go
@@ -370,9 +370,6 @@ func (mux *MuxAPI) comb() {
 		mux.handlers[i] = h
 	}
 
-	// check path params defined, and panic if there is any error.
-	mux.checkPathParams()
-
 	mux.path = mux.pattern
 	if mux.parent != nil {
 		mux.path = path.Join(mux.parent.path, mux.path)
@@ -380,6 +377,9 @@ func (mux *MuxAPI) comb() {
 		mux.paramInfos = append(mux.parent.paramInfos, mux.paramInfos...)
 		mux.handlers = append(mux.parent.handlers, mux.handlers...)
 	}
+
+	// check path params defined, and panic if there is any error.
+	mux.checkPathParams()
 
 	// Get distinct and sorted parameters information.
 	mux.paramInfos = distinctAndSortedParamInfos(mux.paramInfos)
@@ -402,19 +402,19 @@ func (mux *MuxAPI) checkPathParams() {
 		if paramInfo.In != "path" {
 			continue
 		}
-		if !strings.Contains(mux.pattern, "/:"+paramInfo.Name) && !strings.Contains(mux.pattern, "/*"+paramInfo.Name) {
+		if !strings.Contains(mux.path, "/:"+paramInfo.Name) && !strings.Contains(mux.path, "/*"+paramInfo.Name) {
 			mux.frame.Log().Panicf(
 				"[Faygo-checkPathParams] the router pattern `%s` does not match the path param:\n%#v",
-				mux.pattern,
+				mux.path,
 				paramInfo,
 			)
 		}
 		numPathParams++
 	}
-	if countPathParams(mux.pattern) < numPathParams {
+	if countPathParams(mux.path) < numPathParams {
 		mux.frame.Log().Panicf(
 			"[Faygo-checkPathParams] the router pattern `%s` does not match the path params:\n%#v",
-			mux.pattern,
+			mux.path,
 			mux.paramInfos,
 		)
 	}


### PR DESCRIPTION
检测path参数时，应检查整个路径是否包含所需path参数，而不是仅检查当前MuxAPI的pattern是否包含所需path参数。
例如：
type Student struct {
	ClassID string `param:"<in:path> <name:classID>"`
	StudentID string `param:"<in:path> <name:studentID>"`
}

func (s *Student) Serve(c *faygo.Context) error {
	fmt.Println(s.ClassID, s.StudentID)
	return nil
}

func main() {
	// New application object, params: name, version
	var app = faygo.New("myapp", "1.0")

	// router
	app.Route(
		app.NewGroup("/classes/:classID",
			app.NewNamedAPI("get student", "GET", "/students/:studentID", &Student{}),
		),
	)
}
修复之前会产生panic，修复之后可以正常通过path参数校验并可以正常调用